### PR TITLE
Fix incorrect usage of `input` on Python 2.x

### DIFF
--- a/onetruepython.py
+++ b/onetruepython.py
@@ -137,7 +137,9 @@ def execute(python=sys.executable):
     finally:
         if ctypes.windll.shell32.IsUserAnAdmin():
             # need_admin pops up a new window that disappears instantly.
-            input("Press any key to continue...")
+            import sys
+            input_function = raw_input if sys.version_info[0] < 3 else input
+            input_function("Press any key to continue...")
 
 def main(argv=None):
     parser = argparse.ArgumentParser(description='Register the One True Python')


### PR DESCRIPTION
On Python 2 this currently raises an exception as `input("Press any key to continue...")` will implicitly attempt to `eval` an empty input string.  On Python 2 we should use `raw_input`